### PR TITLE
Minor corrections to directory/filename

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,7 @@ We can use it by uncommenting the corresponding line at the bottom of `annotatio
 We can then start annotating after calling
 
 ```
-localturk annotation.html examples/input.csv output.csv
+localturk annotation.html example/ner.csv output.csv
 ```
 
 The `output.csv` is an example output.


### PR DESCRIPTION
The ner.csv exists and yet the command points to input.csv.  That input.csv could theoretically be produced with the python script, except that's more to show usage (since there's no raw.csv included in the directory).  Also the folder path is "example" without an "s".